### PR TITLE
Strawman Demo of EventLogging

### DIFF
--- a/jupyter_notebook_config.py
+++ b/jupyter_notebook_config.py
@@ -1,0 +1,11 @@
+import logging
+
+c.EventLog.allowed_schemas = [
+    'lab.jupyter.org/command-invocations'
+]
+
+def make_eventlog_sinks(eventlog):
+    # As an example, let's write these to local file
+    return [logging.FileHandler('events.log')]
+
+c.EventLog.handlers_maker = make_eventlog_sinks

--- a/jupyterlab_telemetry/event-schemas/command-invocations.json
+++ b/jupyterlab_telemetry/event-schemas/command-invocations.json
@@ -1,0 +1,23 @@
+{
+    "$id": "lab.jupyter.org/command-invocations",
+    "version": 1,
+    "title": "JupyterLab command invocations",
+    "description": "Records each invocation of any command in JupyterLab",
+    "type": "object",
+    "properties": {
+        "session_id": {
+            "comment": "We should validate that this is a UUID, Is this PII?",
+            "type": "string",
+            "description": "Randomly generated session ID for this user session"
+        },
+        "command_id": {
+            "type": "string",
+            "description": "ID of the command being executed"
+        },
+        "command_args": {
+            "type": "object",
+            "description": "Arguments to the command being executed",
+            "pii": true
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -29,17 +29,17 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@jupyterlab/application": "^0.15.0",
-    "@jupyterlab/apputils": "^0.15.2",
-    "@jupyterlab/coreutils": "^1.0.3",
-    "@jupyterlab/services": "^1.1.1",
+    "@jupyterlab/application": "^0.19.1",
+    "@jupyterlab/apputils": "^0.19.1",
+    "@jupyterlab/coreutils": "^2.2.1",
+    "@jupyterlab/services": "^3.2.1",
     "@phosphor/commands": "^1.4.0",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/widgets": "^1.5.0"
   },
   "devDependencies": {
     "rimraf": "^2.6.1",
-    "typescript": "~2.6.0"
+    "typescript": "^3.4.5"
   },
   "jupyterlab": {
     "extension": true

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+jlpm install
+jlpm run build
+jupyter labextension link .

--- a/postBuild
+++ b/postBuild
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 pip install --no-cache-dir --editable .
+jupyter serverextension enable --py jupyterlab_telemetry --sys-prefix
 
 jlpm install
 jlpm run build

--- a/postBuild
+++ b/postBuild
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+pip install --no-cache-dir --editable .
+
 jlpm install
 jlpm run build
 jupyter labextension link .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# JupyterHub with PR https://github.com/jupyterhub/jupyterhub/pull/2542
+git+https://github.com/yuvipanda/jupyterhub.git@d22e5cfa25ee430fca32b64a3a527723aa0c8fe4

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ setup_dict = dict(
         'Programming Language :: Python :: 3',
     ],
     install_requires=[
-        'notebook'
+        'notebook',
+        'jupyterlab'
     ],
 )
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,25 +4,16 @@
 import {
   JupyterLab, JupyterLabPlugin
 } from '@jupyterlab/application';
-
 import {
-  Dialog, showDialog
-} from '@jupyterlab/apputils';
-
-import {
-  uuid
-} from '@jupyterlab/coreutils';
-
-import {
-  h
-} from '@phosphor/virtualdom';
+  UUID
+} from '@phosphor/coreutils';
 
 import {
   Widget
 } from '@phosphor/widgets';
 
 import {
-  Telemetry, TelemetryHandler
+  TelemetryHandler
 } from './handler';
 
 import '../style/index.css';
@@ -37,79 +28,31 @@ const extension: JupyterLabPlugin<void> = {
   activate: (app: JupyterLab) => {
     const { commands } = app;
     const handler = new TelemetryHandler();
+
     // Make a uuid for this session, which will be its
     // key in the session data.
-    const id = uuid();
-    // A log of executed commands.
-    const commandLog: Telemetry.ICommandExecuted[] = [];
+    const session_id = UUID.uuid4();
+    console.log("WOOHOOO?")
 
     app.restored.then(() => {
-      // Create the disclaimer dialog
-      const headerLogo = h.div({className: 'jp-About-header-logo'});
-      const title = h.span({className: 'jp-About-header'},
-        headerLogo,
-        'JupyterLab UX Survey');
-      const message = 'Are you willing to participate in a ' +
-                      'JupyterLab user-experience survey? ' +
-                      'If you agree, we will log:';
-      const message2 = 'We will NOT track:';
-      const dos = h.ul({},
-        h.li({}, 'The menu items you use'),
-        h.li({}, 'The command palette commands you run'),
-        h.li({}, 'The keyboard shortcuts you invoke'),
-        h.li({}, 'The filebrowser operations you use'),
-      );
-      const donts = h.ul({},
-        h.li({}, 'The contents of any notebooks or other files'),
-        h.li({}, 'The code you run'),
-        h.li({}, 'The commands you give in terminals'),
-      );
-      const disclaimer = h.div({}, message, dos, message2, donts);
-      const body = h.div({ className: 'jp-About-body' },
-        disclaimer
-      );
+      // Add a telemetry icon to the top bar.
+      // We do it after the app has been restored to place it
+      // at the right.
+      const widget = new Widget();
+      widget.addClass('jp-telemetry-icon');
+      widget.id = 'telemetry:icon';
+      widget.node.title = 'Telemetry data is being collected';
+      app.shell.addToTopArea(widget);
 
-      showDialog({
-        title,
-        body,
-        buttons: [
-          Dialog.cancelButton({ label: 'NO WAY!' }),
-          Dialog.okButton({ label: 'SURE!' }),
-        ]
-      }).then(result => {
-        if (result.button.accept) {
-          // Add a telemetry icon to the top bar.
-          // We do it after the app has been restored to place it
-          // at the right.
-          const widget = new Widget();
-          widget.addClass('jp-telemetry-icon');
-          widget.id = 'telemetry:icon';
-          widget.node.title = 'Telemetry data is being collected';
-          app.shell.addToTopArea(widget);
 
-          // When a command is executed, store it in the log.
-          commands.commandExecuted.connect((registry, command) => {
-            const date = new Date();
-            commandLog.push({
-              id: command.id,
-              args: command.args,
-              date: date.toJSON(),
-            });
-          });
-
-          const saveLog = () => {
-            if (commandLog.length === 0) {
-              return;
-            }
-            const outgoing = commandLog.splice(0);
-            handler.save({ id, commands: outgoing }).catch(() => {
-              // If the save fails, put the outgoing list back in the log.
-              commandLog.unshift(...outgoing);
-            });
-          };
-          // Save the log to the server every two minutes.
-          setInterval(saveLog, 120 * 1000);
-        }
+      // When a command is executed, emit it
+      commands.commandExecuted.connect((registry, command) => {
+        console.log("A COMMAND HAS BEEN EXECUTED YO");
+        handler.emit({
+          session_id: session_id,
+          command_id: command.id,
+          command_args: command.args
+        })
       });
     });
   }


### PR DESCRIPTION
This is a pure prototype demo of how the EventLogging
system as described in the [strawman design PR](https://github.com/jupyterlab/jupyterlab-telemetry/pull/2)
 can be implemented. It's a way to play with how things may work, and help us
figure out how to do eventlogging / telemetry in a way
that works for everyone in the community.

The [binder link](https://mybinder.org/v2/gh/yuvipanda/jupyterlab-telemetry/events-demo?urlpath=%2Flab) for this PR puts you in a JupyterLab
instance with this set of extensions running.

All JupyterLab command invocations are logged into a file
in the home directory called `events.log`. 

The events will conform to a well defined, versioned
[JSON Schema](https://github.com/yuvipanda/jupyterlab-telemetry/blob/events-demo/jupyterlab_telemetry/event-schemas/command-invocations.json).
This can be used by analysts to understand their data,
and hopefully can help auto-generate a view for users
to see what data is being collected.,

By default, this data is thrown away. In this PR,
I've [configured it]((https://github.com/yuvipanda/jupyterlab-telemetry/blob/events-demo/jupyter_notebook_config.py).
) to be saved as a file into ~/events.log.

I've had to remove the consent dialog box, since it
no longer built with current JupyterLab - and my JS
skills are not good enough to figure out what has changed
in the last year. 

The Python code for doing validation, emission etc
is coming from this [unmerged PR in JupyterHub](https://github.com/jupyterhub/jupyterhub/pull/2542),
which itself is adopted from production BinderHub code.
Let's keep technical discussions about this there.