### PR TITLE
Initial cut of JupyterLab EventLog

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 A JupyterLab extension for logging and telemetry of usage data
 
-
 ## Prerequisites
 
-* JupyterLab
+* JupyterLab 1.0+
 
 ## Installation
 
@@ -13,20 +12,79 @@ A JupyterLab extension for logging and telemetry of usage data
 jupyter labextension install jupyterlab-telemetry
 ```
 
+## Usage
+
+Define handlers that can receive events from the `EventLog`
+
+```typescript
+import { EventLog } from "@jupyterlab/jupyterlab-telemetry";
+
+function consoleHandler(el: EventLog, events: EventLog.RecordedEvent[]) {
+  console.log(`[Handler1] Received events ${JSON.stringify(events)}`)
+}
+
+function consoleHandler2(el: EventLog, events: EventLog.RecordedEvent[]) {
+  console.log(`[Handler2] Received events ${JSON.stringify(events)}`)
+}
+```
+
+Create an instance of the EventLog and configure the handler and other options from `EventLog.IOptions`
+
+```typescript
+
+const el = new EventLog({
+  handlers: [consoleHandler, consoleHandler2],
+  allowedSchemas: ['org.jupyter.foo', 'org.jupyterlab.commands.docmanager:open'],
+  commandRegistry: app.commands,
+  commandEmitIntervalSeconds: 2
+});
+```
+
+Send custom events via the `recordEvents` interface. If the `commandRegistry` instance was passed, then the `EventLog`  will subscribe to commands executed in the JuptyerLab application and send the whitelisted ones to each configured handler.
+
+```typescript
+el.recordEvent({
+  schema: 'org.jupyter.foo',
+  version: 1,
+  body: {
+    'foo': 'bar'
+  }
+});
+
+```
+
+Dispose the event log after use
+
+```typescript
+el.dispose();
+```
+
 ## Development
 
-For a development install (requires npm version 4 or later), do the following in the repository directory:
+For a development install, do the following in the repository directory:
 
 ```bash
-npm install
-npm run build
-jupyter labextension link .
+yarn
+yarn build
+jupyter labextension install .
 ```
 
 To rebuild the package and the JupyterLab app:
 
 ```bash
-npm run build
+yarn build
 jupyter lab build
 ```
 
+To auto-build the package and JupyterLab on any change:
+
+```bash
+
+# In one terminal
+yarn watch
+
+# In second terminal
+
+jupyter lab --watch
+
+```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jupyterlab/jupyterlab-telemetry",
   "version": "0.1.0",
-  "description": "A JupyterLab extension for logging and telemetry of usage data",
+  "description": "A JupyterLab library for logging and telemetry of usage data",
   "keywords": [
     "jupyter",
     "jupyterlab",
@@ -32,9 +32,10 @@
   "dependencies": {
     "@jupyterlab/application": "^1.0.0",
     "@jupyterlab/apputils": "^1.0.0",
+    "@phosphor/coreutils": "1.3.1",
     "@phosphor/messaging": "^1.2.3",
-    "@phosphor/widgets": "^1.8.1",
-    "@phosphor/coreutils": "1.3.1"
+    "@phosphor/signaling": "^1.3.0",
+    "@phosphor/widgets": "^1.8.1"
   },
   "devDependencies": {
     "rimraf": "^2.6.1",

--- a/src/eventlog.ts
+++ b/src/eventlog.ts
@@ -1,0 +1,176 @@
+import { Signal, Slot } from "@phosphor/signaling";
+import { CommandRegistry } from "@phosphor/commands";
+import { IDisposable } from "@phosphor/disposable";
+
+/**
+ * A configurable Event Log for publishing and receiving JupyterLab events.
+ */
+export class EventLog implements IDisposable {
+    private readonly handlers: Slot<EventLog, EventLog.RecordedEvent[]>[];
+    private readonly allowedSchemas: string[];
+
+    private readonly _eventSignal: Signal<EventLog, EventLog.RecordedEvent[]>
+    private readonly _commandLog: EventLog.RecordedEvent[]
+    private _isDisposed: boolean;
+    private _saveInterval: number;
+
+    constructor(options: EventLog.IOptions) {
+        this.handlers = options.handlers;
+        this.allowedSchemas = options.allowedSchemas
+        this._eventSignal = new Signal(this)
+        this._commandLog = []
+
+        for (const handler of this.handlers) {
+            this._eventSignal.connect(handler);
+        }
+
+        if (options.commandRegistry) {
+            this.enableCommandEvents(options);
+        } else {
+            console.log(`No commandRegistry provided. Not publishing JupyterLab command events.`)
+        }
+    }
+
+    /**
+     * Get whether the Event Log is disposed.
+     */
+    get isDisposed(): boolean {
+        return this._isDisposed;
+    }
+
+    /**
+    * Dispose of the resources used by the EventLog.
+    */
+    dispose(): void {
+        if (this.isDisposed) {
+            return;
+        }
+        clearInterval(this._saveInterval);
+        Signal.clearData(this);
+        this._isDisposed = true;
+    }
+
+    /**
+     * The interface for event publishers to record a single event.
+     * 
+     * - Validate that the event schema is whitelisted
+     * - Validate that the event schema is valid
+     * - Emit the event to the configured handlers.
+     * @param event the event to record
+     */
+    public recordEvent(event: EventLog.Event): Promise<void> {
+        if (!this.isSchemaWhitelisted(event.schema)) {
+            return;
+        }
+
+        if (!this.isSchemaValid(event)) {
+            return;
+        }
+
+        this._eventSignal.emit([{
+            ...event,
+            publishTime: new Date()
+        }])
+    }
+
+    /**
+     * TODO: Implement schema validation. 
+     */
+    private isSchemaValid(event: EventLog.Event): boolean {
+        return true
+    }
+
+    /**
+     * TODO: Make this configurable via Settings Registry
+     */
+    private isSchemaWhitelisted(schemaName: string): boolean {
+        return this.allowedSchemas.indexOf(schemaName) > -1;
+    }
+
+    /**
+    * Subscribe the EventLog instance to all command executions in the JupyterLab application.
+    *
+    * Batches command events in-memory before emitting to each event handler.
+    *
+    * @param options the EventLog instantiation options.
+    */
+    private enableCommandEvents(options: EventLog.IOptions) {
+        options.commandRegistry.commandExecuted.connect((registry, command) => {
+            const commandEventSchema = `org.jupyterlab.commands.${command.id}`;
+            if (this.isSchemaWhitelisted(commandEventSchema)) {
+                this._commandLog.push({
+                    schema: `org.jupyterlab.commands.${command.id}`,
+                    body: command.args,
+                    version: 1,
+                    publishTime: new Date()
+                });
+            }
+        });
+        const saveLog = () => {
+            if (this._commandLog.length === 0) {
+                return;
+            }
+            const outgoing = this._commandLog.splice(0);
+            this._eventSignal.emit(outgoing)
+        };
+        this._saveInterval = setInterval(saveLog, options.commandEmitIntervalSeconds !== undefined ? options.commandEmitIntervalSeconds * 1000 : 120 * 1000);
+    }
+}
+
+/**
+ * A namespace for `EventLog` data.
+ */
+export namespace EventLog {
+    /**
+     * The instantiation options for an EventLog
+     */
+    export interface IOptions {
+        /**
+         * The list of schema IDs to whitelist for the EventLog instance.
+         */
+        allowedSchemas: string[],
+
+        /**
+         * The list of event handlers to subscribe to the EventLog instance
+         */
+        handlers: Slot<EventLog, EventLog.RecordedEvent[]>[],
+
+        /**
+         * The `CommandRegistry` instance from the JupyterLab application. 
+         * If provided, this causes the EventLog to subscribe to JupyterLab command executions and 
+         * emit events to the provided handlers.
+         * 
+         * Individual commands still need to be whitelisted using the `org.jupyterlab.commands.$COMMAND_ID` schema ID.
+         */
+        commandRegistry?: CommandRegistry,
+
+        /**
+         * The interval, in seconds, for which JupyterLab command events are batched in-memory before being emitted
+         * to the provided handlers.
+         * 
+         * If not provided, the default interval is 120 seconds (2 minutes).
+         */
+        commandEmitIntervalSeconds?: number
+    }
+
+    /**
+     * The model to represent an event being received from a publisher.
+     * The event body needs to conform to the given schema.
+     */
+    export interface Event {
+        schema: string,
+        version: number,
+        body: any
+    }
+
+    /**
+     * The model to represent an event being sent to a handler. This includes additional
+     * metadata that is added by the EventLog.
+     */
+    export interface RecordedEvent {
+        schema: string,
+        version: number,
+        body: any
+        publishTime: Date
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,8 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { JupyterFrontEnd, JupyterFrontEndPlugin } from '@jupyterlab/application';
-import { Dialog, showDialog } from '@jupyterlab/apputils';
-import { UUID } from '@phosphor/coreutils';
-import { Widget } from '@phosphor/widgets';
+
 import '../style/index.css';
-import { Telemetry, TelemetryHandler } from './handler';
 
 /**
  * Initialization data for the jupyterlab-telemetry extension.
@@ -15,67 +12,9 @@ const extension: JupyterFrontEndPlugin<void> = {
   id: 'jupyterlab-telemetry',
   autoStart: true,
   activate: (app: JupyterFrontEnd) => {
-    const { commands } = app;
-    const handler = new TelemetryHandler();
-    const id = UUID.uuid4()
-    // A log of executed commands.
-    const commandLog: Telemetry.ICommandExecuted[] = [];
-
-    app.restored.then(() => {
-      // Create the disclaimer dialog
-      const title = 'JupyterLab UX Survey'
-      const message = 'Are you willing to participate in a ' +
-                      'JupyterLab user-experience survey? ' +
-                      'If you agree, we will log:';
-      const message2 = 'We will NOT track:';
-      const dos = 'The menu items you use, the command palette commands you run, the keyboard shortcuts you invoke, the keyboard shortcuts you invoke, the filebrowser operations you use.'
-      const donts = 'The contents of any notebooks or other files, the code you run, or the commands you give in terminals.'
-      const body = `${message} ${dos} ${message2} ${donts}`
-
-      showDialog({
-        title,
-        body,
-        buttons: [
-          Dialog.cancelButton({ label: 'NO WAY!' }),
-          Dialog.okButton({ label: 'SURE!' }),
-        ]
-      }).then(result => {
-        if (result.button.accept) {
-          // Add a telemetry icon to the top bar.
-          // We do it after the app has been restored to place it
-          // at the right.
-          const widget = new Widget();
-          widget.addClass('jp-telemetry-icon');
-          widget.id = 'telemetry:icon';
-          widget.node.title = 'Telemetry data is being collected';
-          app.shell.add(widget, 'top');
-
-          // When a command is executed, store it in the log.
-          commands.commandExecuted.connect((registry, command) => {
-            const date = new Date();
-            commandLog.push({
-              id: command.id,
-              args: command.args,
-              date: date.toJSON(),
-            });
-          });
-
-          const saveLog = () => {
-            if (commandLog.length === 0) {
-              return;
-            }
-            const outgoing = commandLog.splice(0);
-            handler.save({ id, commands: outgoing }).catch(() => {
-              // If the save fails, put the outgoing list back in the log.
-              commandLog.unshift(...outgoing);
-            });
-          };
-          // Save the log to the server every two minutes.
-          setInterval(saveLog, 120 * 1000);
-        }
-      });
-    });
+    console.log('Telemetry extension activated');
   }
 };
 
 export default extension;
+export * from './eventlog'


### PR DESCRIPTION
* Provides a way to subscribe handlers to the EventLog. The fan-out of events to each configured "handler" is done with PhoshporJS signals under the hood.
* The `recordEvent` method allows publishers to send custom events to each configured handler
* The EventLog can also subscribe to the JupyterLab CommandRegistry automatically and send JupyterLab commands to each handler.

Other features which will be added incrementally
- Schema validation and Settings Registry integration