### PR TITLE
Remove extension and style metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "A JupyterLab library for logging and telemetry of usage data",
   "keywords": [
     "jupyter",
-    "jupyterlab",
-    "jupyterlab-extension"
+    "jupyterlab"
   ],
   "homepage": "https://github.com/jupyterlab/jupyterlab-telemetry",
   "bugs": {
@@ -19,7 +18,6 @@
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "style": "style/index.css",
   "repository": {
     "type": "git",
     "url": "https://github.com/jupyterlab/telemetry"
@@ -40,8 +38,5 @@
   "devDependencies": {
     "rimraf": "^2.6.1",
     "typescript": "~3.5.2"
-  },
-  "jupyterlab": {
-    "extension": true
   }
 }


### PR DESCRIPTION
Follow up to #13.  This is now a standard JS package, not an extension.