### PR TITLE
Automated Changelog Entry for 1.0.2 on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,19 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 1.0.2
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab-telemetry/compare/be69b652192d5dc25bb30a9455b3e0685f7773c8...15ef01e0b9c72fdb5c1d7b02638342814f20a55d))
+
+### Merged PRs
+
+- Fix for build workflow [#25](https://github.com/jupyterlab/jupyterlab-telemetry/pull/25) ([@3coins](https://github.com/3coins))
+- Upgrade to make compatible with JupyterLab 3 [#24](https://github.com/jupyterlab/jupyterlab-telemetry/pull/24) ([@3coins](https://github.com/3coins))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab-telemetry/graphs/contributors?from=2022-03-16&to=2022-03-23&type=c))
+
+[@3coins](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab-telemetry+involves%3A3coins+updated%3A2022-03-16..2022-03-23&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab-telemetry+involves%3Ablink1073+updated%3A2022-03-16..2022-03-23&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab-telemetry+involves%3Afcollonval+updated%3A2022-03-16..2022-03-23&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab-telemetry+involves%3Awelcome+updated%3A2022-03-16..2022-03-23&type=Issues)
+
 <!-- <END NEW CHANGELOG ENTRY> -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 1.0.2
 
-([Full Changelog](https://github.com/jupyterlab/jupyterlab-telemetry/compare/be69b652192d5dc25bb30a9455b3e0685f7773c8...15ef01e0b9c72fdb5c1d7b02638342814f20a55d))
+([Full Changelog](https://github.com/jupyterlab/jupyterlab-telemetry/compare/3c1b81e3591f18326a653410f2a59bb5f6d7546d...15ef01e0b9c72fdb5c1d7b02638342814f20a55d))
 
 ### Merged PRs
 


### PR DESCRIPTION
Automated Changelog Entry for 1.0.2 on master

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab-telemetry  |
| Branch  | master  |
| Version Spec | 1.0.2 |
| Since |3c1b81e3591f18326a653410f2a59bb5f6d7546d |