### PR TITLE
Automated Changelog Entry for 1.0.2 on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,21 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 1.0.2
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab-telemetry/compare/@jupyterlab/jupyterlab-telemetry@0.3.1...15ef01e0b9c72fdb5c1d7b02638342814f20a55d))
+
+### Merged PRs
+
+- Fix for build workflow [#25](https://github.com/jupyterlab/jupyterlab-telemetry/pull/25) ([@3coins](https://github.com/3coins))
+- Upgrade to make compatible with JupyterLab 3 [#24](https://github.com/jupyterlab/jupyterlab-telemetry/pull/24) ([@3coins](https://github.com/3coins))
+- Bump postcss from 7.0.18 to 7.0.36 [#20](https://github.com/jupyterlab/jupyterlab-telemetry/pull/20) ([@dependabot](https://github.com/dependabot))
+- Bump ws from 7.1.2 to 7.4.6 [#19](https://github.com/jupyterlab/jupyterlab-telemetry/pull/19) ([@dependabot](https://github.com/dependabot))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab-telemetry/graphs/contributors?from=2020-03-16&to=2022-03-23&type=c))
+
+[@3coins](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab-telemetry+involves%3A3coins+updated%3A2020-03-16..2022-03-23&type=Issues) | [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab-telemetry+involves%3Ablink1073+updated%3A2020-03-16..2022-03-23&type=Issues) | [@dependabot](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab-telemetry+involves%3Adependabot+updated%3A2020-03-16..2022-03-23&type=Issues) | [@ellisonbg](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab-telemetry+involves%3Aellisonbg+updated%3A2020-03-16..2022-03-23&type=Issues) | [@fcollonval](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab-telemetry+involves%3Afcollonval+updated%3A2020-03-16..2022-03-23&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab-telemetry+involves%3Awelcome+updated%3A2020-03-16..2022-03-23&type=Issues)
+
 <!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 1.0.2 on master

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab-telemetry  |
| Branch  | master  |
| Version Spec | 1.0.2 |
| Since Last Stable | true |